### PR TITLE
Combine Google Font stylesheets, save HTTP request

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,8 +12,7 @@
     <meta http-equiv="content-language" content="en-gb" />
     <meta name="description" content="Fluid, responsive blog theme for Jekyll.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,700' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic' rel='stylesheet' type='text/css'>
+    <link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,700|Lora:400,700,400italic" rel="stylesheet" type="text/css">
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/main.css" />
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/syntax.css" />
 </head>


### PR DESCRIPTION
Google Fonts supports loading multiple fonts in the same stylesheet
request by delimiting the fonts with pipe (|) characters. Combine Open
Sans and Lora into a single stylesheet request to remove an HTTP request
to fonts.googleapis.com.

You can open the stylesheet in your browser to confirm the styles are all
there: http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,700|Lora:400,700,400italic
