### PR TITLE
Set baseurl to blank for expected behavior

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ description: "Fluid, responsive blog theme for Jekyll"
 author: "John Doge"
 
 url: "http://m3xm.github.io"
-baseurl: /hikari-for-Jekyll
+baseurl: ""
 
 markdown: rdiscount
 permalink: :year/:month/:title.html


### PR DESCRIPTION
When cloning this theme, it's expected that Jekyll will serve the site
from the root. "baseurl" must be set to an empty string since the
default is "/", which breaks the absolute URLs defined in the templates.

Fixes #8.
