### PR TITLE
Remove class on click to prevent lingering hover effect

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -139,11 +139,11 @@ header .h-wrap .menu-icon .lines::after {
   top: -10px;
 }
 
-header .h-wrap .menu-icon:hover .lines:before {
+header .h-wrap .menu-icon.hover .lines:before {
   top: -0.0219rem;
 }
 
-header .h-wrap .menu-icon:hover .lines:after {
+header .h-wrap .menu-icon.hover .lines:after {
   top: 0.0219rem;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -8,23 +8,38 @@ window.onload = function() {
     $menuIcon.addEventListener('click', function() {
         toggleClass($menuIcon, 'close');
         toggleClass($offCanva, 'toggled');
+        removeClass($menuIcon, 'hover');
     }, false);
+
+    $menuIcon.addEventListener('mouseenter', function() {
+        addClass($menuIcon, 'hover');
+    });
+
+    $menuIcon.addEventListener('mouseleave', function() {
+        removeClass($menuIcon, 'hover');
+    });
+
+    function addClass(element, className) {
+        element.className += " " + className;
+    }
+
+    function removeClass(element, className) {
+        // Capture any surrounding space characters to prevent repeated
+        // additions and removals from leaving lots of spaces.
+        var classNameRegEx = new RegExp("\\s*" + className + "\\s*");
+        element.className = element.className.replace(classNameRegEx, " ");
+    }
 
     function toggleClass(element, className) {
         if (!element || !className) {
             return;
         }
 
-        var classString = element.className,
-            nameIndex = classString.indexOf(className);
-
-        if (nameIndex == -1) {
-            classString += ' ' + className;
+        if (element.className.indexOf(className) === -1) {
+            addClass(element, className);
+        } else {
+            removeClass(element, className);
         }
-        else {
-            classString = classString.substr(0, nameIndex) + classString.substr(nameIndex+className.length);
-        }
-        element.className = classString;
     }
 
     // Open Twitter/share in a Pop-Up


### PR DESCRIPTION
The CSS :hover selector requires a mouseleave/mouseout to remove its
effect, and because of the sliding top bar the mouseleave doesn't
happen on touch devices.

By adding and removing a "hover" class name, the JS can remove the
"hover" on click as well to prevent having to wait for a mouse out.

Fixes #7.
