### PR TITLE
Use schemeless href to work over HTTP and HTTPS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
       <meta http-equiv="content-language" content="en-gb" />
       <meta name="description" content="Fluid, responsive blog theme for Jekyll.">
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,700|Lora:400,700,400italic" rel="stylesheet" type="text/css">
+      <link href="//fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,700|Lora:400,700,400italic" rel="stylesheet" type="text/css">
       <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/main.css" />
       <link href="atom.xml" type="application/atom+xml" rel="alternate" title="Site ATOM Feed">
   </head>


### PR DESCRIPTION
Linking to “http:” for Google Fonts prevents the site from working when
loaded over “https:”. By removing the scheme, the browser will use the
scheme over which the parent page was loaded. HTTP and HTTPS will work
fine some googleapis.com works over HTTPS.
