### PR TITLE
fixes #28

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
       <meta name="description" content="Fluid, responsive blog theme for Jekyll.">
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
       <link href="//fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,700|Lora:400,700,400italic" rel="stylesheet" type="text/css">
-      <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/main.css" />
+      <link rel="stylesheet" type="text/css" href="{{ site.baseurl| split: '/' | join:'/' }}/css/main.css" />
       <link href="atom.xml" type="application/atom+xml" rel="alternate" title="Site ATOM Feed">
   </head>
 
@@ -52,7 +52,7 @@
 
       <header>
         <div class="h-wrap">
-          <h1 class="title"><a href="{{ site.baseurl }}" title="Back to Homepage">{{ site.name }}</a></h1>
+          <h1 class="title"><a href="{{ site.baseurl | split:'/' | join:'/' | append:'/'  }}" title="Back to Homepage">{{ site.name }}</a></h1>
           <a class="menu-icon" title="Open Bio"><span class="lines"></span></a>
         </div>
       </header>


### PR DESCRIPTION
https://github.com/m3xm/hikari-for-Jekyll/issues/28

fix for stylesheets:
ensure that if baseurl is "mysite.com/" that the css path generated is
mysite.com/css/main.css
{{ site.baseurl| split: '/' | join:'/' }}/css/main.css

fix for link home:
ensure that link to home defaults to "/" even if baseurl is empty string
{{ site.baseurl | split:'/' | join:'/' | append:'/'  }}

reference to to liquid tags:
https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#tags