### PR TITLE
fixed index.html so it properly paginates

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ title: Homepage
 
 <div id="home">
   <ul class="posts">
-    {% for post in site.posts %}
+    {% for post in paginator.posts %}
     <li itemscope itemtype="http://schema.org/BlogPosting">
       <a href="{{ site.baseurl }}{{ post.url }}" itemprop="url">
         <div class="p-wrap">


### PR DESCRIPTION
The theme before always displayed all the posts because the it looped over site.posts.  To work with pagination in `_config.yml` you'll need to loop over `paginator.posts`