### PR TITLE
Be consistent with social link generation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,16 +32,16 @@
         <h6>Follow me on</h6>
         <ul>
           {% if site.twitter %}
-          <li><a target="_blank" href="http://twitter.com/{{ site.twitter }}">Twitter</a></li>
+          <li><a target="_blank" href="https://twitter.com/{{ site.twitter }}">Twitter</a></li>
           {% endif %}
           {% if site.github %}
-          <li><a target="_blank" href="http://github.com/{{ site.github }}">Github</a></li>
+          <li><a target="_blank" href="https://github.com/{{ site.github }}">Github</a></li>
           {% endif %}
           {% if site.dribbble %}
-          <li><a target="_blank" href="http://dribbble.com/{{ site.dribbble }}">Dribbble</a></li>
+          <li><a target="_blank" href="https://dribbble.com/{{ site.dribbble }}">Dribbble</a></li>
           {% endif %}
           {% if site.instagram %}
-          <li><a target="_blank" href="http://instagram.com/{{ site.instagram }}">Instagram</a></li>
+          <li><a target="_blank" href="https://instagram.com/{{ site.instagram }}">Instagram</a></li>
           {% endif %}
         </ul>
       </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,13 +35,13 @@
           <li><a target="_blank" href="http://twitter.com/{{ site.twitter }}">Twitter</a></li>
           {% endif %}
           {% if site.github %}
-          <li><a target="_blank" href="{{ site.github }}">Github</a></li>
+          <li><a target="_blank" href="http://github.com/{{ site.github }}">Github</a></li>
           {% endif %}
           {% if site.dribbble %}
-          <li><a target="_blank" href="{{ site.dribbble }}">Dribbble</a></li>
+          <li><a target="_blank" href="http://dribbble.com/{{ site.dribbble }}">Dribbble</a></li>
           {% endif %}
           {% if site.instagram %}
-          <li><a target="_blank" href="{{ site.instagram }}">Instagram</a></li>
+          <li><a target="_blank" href="http://instagram.com/{{ site.instagram }}">Instagram</a></li>
           {% endif %}
         </ul>
       </nav>
@@ -65,7 +65,7 @@
         <small>Powered by Jekyll - Theme: <a href="https://github.com/m3xm/hikari-for-Jekyll">hikari</a> - &copy; {{ site.author }}</small>
       </footer>
 
-    </div> 
+    </div>
     {% comment %} site-wrapper {% endcomment %}
 
     <script src="{{ site.baseurl }}/js/main.js"></script>


### PR DESCRIPTION
Love the theme.

I noticed that the way Twitter links are constructed in `default.html` was different than Github, Dribbble and Instagram links: 

`default.html` expects `site.twitter` to contain only your Twitter handle, where `site.github`, `site.dribbble` and `site.instagram` are expected to be complete URL strings.

This pull changes this so that the template only requires a handle.