### PR TITLE
Fix left-alignment of titles on home screen

### DIFF
--- a/_scss/pages/_home.scss
+++ b/_scss/pages/_home.scss
@@ -1,26 +1,26 @@
-.posts { 
+.posts {
   overflow: hidden;
-  li { 
-    display: inline-block; 
-    width: 100%; 
-    border-bottom: 1px solid darken($main-color, 6%); 
-    
+  li {
+    display: inline-block;
+    width: 100%;
+    border-bottom: 1px solid darken($main-color, 6%);
+
     &:first-child {
-      border-top: 1px solid darken($main-color, 6%); 
+      border-top: 1px solid darken($main-color, 6%);
     }
 
     .p-wrap {
       padding: $spacing-ml $spacing-m;
-      background: $main-color; 
+      background: $main-color;
       transition: all .15s ease-in;
-      &:active { 
+      &:active {
         background: darken($main-color, 3%);
       }
       &:hover {
-        background: lighten($main-color, 3%); 
+        background: lighten($main-color, 3%);
         padding-left: $spacing-m + $spacing-s;
         &::after {
-          content:'\2192'; 
+          content:'\2192';
           margin-left: $spacing-xs;
           @media (max-width: 942px) {
             content: none;
@@ -38,15 +38,18 @@
     } // end .p-wrap
 
     time {
-      color: darken($main-color, 20%); 
+      color: darken($main-color, 20%);
+      display: inline-block;
       padding-right: $spacing-s;
+      width: 155px;
       @media (max-width: 942px) {
         display: block;
+        width: auto;
       }
     }
 
     a {
-      color: white; 
+      color: white;
       text-decoration: none;
     }
 


### PR DESCRIPTION
Last one! :-)

I noticed that articles are not consistently aligned on the home screen. This pull ensures that titles are always lined up. Tested it with one of the longest date strings (30 Sep 2020).

**Before:**
![screen shot 2015-04-01 at 4 17 31 pm](https://cloud.githubusercontent.com/assets/74452/6951718/47d6144c-d88b-11e4-8121-2db35510390f.png)

**After:**
![screen shot 2015-04-01 at 4 23 02 pm](https://cloud.githubusercontent.com/assets/74452/6951733/683d9282-d88b-11e4-9882-806de4c88ff5.png)
